### PR TITLE
Add the feature to read urltype from config (for GHE etc)

### DIFF
--- a/git_command.go
+++ b/git_command.go
@@ -61,12 +61,12 @@ func (git Git) clone(repo string) (string, error) {
 }
 
 // git config name
-func (git Git) getConfig(name, defaultValue string) (string, error) {
+func (git Git) getConfig(name, defaultValue string) string {
 	configValue, err := git.exec("config", "--get", name)
 	if err != nil {
-		return defaultValue, nil
+		return defaultValue
 	}
-	return configValue, nil
+	return configValue
 }
 
 func (git Git) exec(args ...string) (string, error) {

--- a/git_remote.go
+++ b/git_remote.go
@@ -3,13 +3,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	giturls "github.com/whilp/git-urls"
-	neturl "net/url"
 )
 
 // GitRemote is a struct
@@ -57,6 +57,11 @@ func (r GitRemote) remoteURL(branch string, line string) (string, error) {
 		return remote, err
 	}
 
+	// If it cannot be determined from the remote domain,
+	//   read the setting from git config and make a judgment based on it.
+	urlType := r.git.getConfig("gh-open.urltype", "")
+	scheme := r.git.getConfig("gh-open.protocol", "https")
+
 	url, err := giturls.Parse(remote)
 	if err != nil {
 		return "", err
@@ -65,7 +70,7 @@ func (r GitRemote) remoteURL(branch string, line string) (string, error) {
 	// remove .git from /inouet/gh-open.git
 	path := strings.TrimSuffix(url.Path, ".git")
 	newURL := neturl.URL{
-		Scheme: "https",
+		Scheme: scheme,
 		Host:   url.Host,
 		Path:   path,
 	}
@@ -81,7 +86,7 @@ func (r GitRemote) remoteURL(branch string, line string) (string, error) {
 		}
 	}
 
-	remoteURL, err := buildURL(newURL, r.path, branch, line)
+	remoteURL, err := buildURL(newURL, r.path, branch, line, urlType)
 	if err != nil {
 		return "", err
 	}

--- a/git_remote.go
+++ b/git_remote.go
@@ -12,6 +12,11 @@ import (
 	giturls "github.com/whilp/git-urls"
 )
 
+const (
+	gitConfigUrlTypeName  string = "gh-open.urltype"
+	gitConfigProtocolName string = "gh-open.protocol"
+)
+
 // GitRemote is a struct
 type GitRemote struct {
 	git  *Git
@@ -59,8 +64,8 @@ func (r GitRemote) remoteURL(branch string, line string) (string, error) {
 
 	// If it cannot be determined from the remote domain,
 	//   read the setting from git config and make a judgment based on it.
-	urlType := r.git.getConfig("gh-open.urltype", "")
-	scheme := r.git.getConfig("gh-open.protocol", "https")
+	urlType := r.git.getConfig(gitConfigUrlTypeName, "")
+	scheme := r.git.getConfig(gitConfigProtocolName, "https")
 
 	url, err := giturls.Parse(remote)
 	if err != nil {

--- a/git_remote_test.go
+++ b/git_remote_test.go
@@ -125,6 +125,33 @@ func TestRemoteUrlFunctional(t *testing.T) {
 	}
 }
 
+func TestConfig(t *testing.T) {
+	testDir := mkTempDir()
+	defer os.RemoveAll(testDir)
+
+	git, _ := newGit(testDir)
+	git.clone("https://github.com/githubtraining/github-cheat-sheet.git")
+
+	path := filepath.Join(testDir, "/github-cheat-sheet")
+	git, _ = newGit(path)
+
+	// set config
+	git.exec("config", "gh-open.urltype", "bitbucket.org")
+	git.exec("config", "gh-open.protocol", "http")
+
+	gr, err := newGitRemote(filepath.Join(path, "LICENSE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := gr.remoteURL("master", "3-4")
+
+	// Expect bitbucket style url and http protocol
+	want := "http://github.com/githubtraining/github-cheat-sheet/src/master/LICENSE#lines-3:4"
+	if got != want {
+		t.Errorf("want '%s', got '%s'\n", want, got)
+	}
+}
+
 func TestNewGitRemote(t *testing.T) {
 
 	emptyDir := mkTempDir()

--- a/git_remote_test.go
+++ b/git_remote_test.go
@@ -136,8 +136,8 @@ func TestConfig(t *testing.T) {
 	git, _ = newGit(path)
 
 	// set config
-	git.exec("config", "gh-open.urltype", "bitbucket.org")
-	git.exec("config", "gh-open.protocol", "http")
+	git.exec("config", gitConfigUrlTypeName, "bitbucket.org")
+	git.exec("config", gitConfigProtocolName, "http")
 
 	gr, err := newGitRemote(filepath.Join(path, "LICENSE"))
 	if err != nil {

--- a/git_remote_test.go
+++ b/git_remote_test.go
@@ -52,7 +52,7 @@ func TestRemoteUrl(t *testing.T) {
 	for name, c := range cases {
 		gr, err := newGitRemote(c.path)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 		got, _ := gr.remoteURL(c.branch, c.line)
 		if got != c.want {
@@ -113,11 +113,11 @@ func TestRemoteUrlFunctional(t *testing.T) {
 		path := filepath.Join(gitDir, c.path)
 		gr, err := newGitRemote(path)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 		got, err := gr.remoteURL(c.branch, c.line)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 		if got != c.want {
 			t.Errorf("%s want '%s', got '%s'\n", name, c.want, got)

--- a/git_service.go
+++ b/git_service.go
@@ -31,12 +31,14 @@ func buildBitbucketURL(baseURL url.URL, filePath, branch string, line string) st
 	filePath = strings.TrimLeft(filePath, "/")
 
 	lineStr := ""
-	arr := strings.Split(line, "-")
-	if len(arr) == 1 {
-		lineStr = fmt.Sprintf("#lines-%s", arr[0])
-	}
-	if len(arr) == 2 {
-		lineStr = fmt.Sprintf("lines-%s:%s", arr[0], arr[1])
+	if line != "" {
+		arr := strings.Split(line, "-")
+		if len(arr) == 1 {
+			lineStr = fmt.Sprintf("lines-%s", arr[0])
+		}
+		if len(arr) == 2 {
+			lineStr = fmt.Sprintf("lines-%s:%s", arr[0], arr[1])
+		}
 	}
 	baseURL.Path = fmt.Sprintf("%s/src/%s/%s", baseURL.Path, branch, filePath)
 	baseURL.Fragment = lineStr

--- a/git_service.go
+++ b/git_service.go
@@ -7,18 +7,17 @@ import (
 	"strings"
 )
 
-type buildURLFunc func(url url.URL, filePath, branch string, line string) string
+type buildURLFunc func(url url.URL, filePath, branch, line string) string
 
 // buildGithubURL build URL for Github
 //   Format: https://github.com/<user>/<repos>/tree/<branch>/path/to/file.txt#L10-20
-func buildGithubURL(baseURL url.URL, filePath, branch string, line string) string {
+func buildGithubURL(baseURL url.URL, filePath, branch, line string) string {
 	filePath = strings.TrimLeft(filePath, "/")
 
 	lineStr := ""
 	if line != "" {
 		lineStr = "L" + line
 	}
-
 	baseURL.Path = fmt.Sprintf("%s/tree/%s/%s", baseURL.Path, branch, filePath)
 	baseURL.Fragment = lineStr
 
@@ -27,7 +26,7 @@ func buildGithubURL(baseURL url.URL, filePath, branch string, line string) strin
 
 // buildBitbucketURL build URL for bitbucket
 //   Format: https://bitbucket.org/<user>/<repos>/src/<branch>/file.txt#lines-10:20
-func buildBitbucketURL(baseURL url.URL, filePath, branch string, line string) string {
+func buildBitbucketURL(baseURL url.URL, filePath, branch, line string) string {
 	filePath = strings.TrimLeft(filePath, "/")
 
 	lineStr := ""
@@ -47,7 +46,7 @@ func buildBitbucketURL(baseURL url.URL, filePath, branch string, line string) st
 
 // buildGitlabURL build URL for gitlab
 //  Format: https://gitlab.com/<user>/<repos>/-/blob/<branch>/file.txt#L10-20
-func buildGitlabURL(baseURL url.URL, filePath, branch string, line string) string {
+func buildGitlabURL(baseURL url.URL, filePath, branch, line string) string {
 	filePath = strings.TrimLeft(filePath, "/")
 
 	lineStr := ""
@@ -60,8 +59,8 @@ func buildGitlabURL(baseURL url.URL, filePath, branch string, line string) strin
 	return baseURL.String()
 }
 
-func buildURL(baseURL url.URL, path, branch, line string) (string, error) {
-	buildFunc, err := getGitURLBuilder(baseURL)
+func buildURL(baseURL url.URL, path, branch, line, urlType string) (string, error) {
+	buildFunc, err := getGitURLBuilder(baseURL, urlType)
 	if err != nil {
 		return "", err
 	}
@@ -70,8 +69,12 @@ func buildURL(baseURL url.URL, path, branch, line string) (string, error) {
 	return remoteURL, nil
 }
 
-func getGitURLBuilder(baseURL url.URL) (buildURLFunc, error) {
-	switch baseURL.Host {
+func getGitURLBuilder(baseURL url.URL, urlType string) (buildURLFunc, error) {
+	host := baseURL.Host
+	if urlType != "" {
+		host = urlType
+	}
+	switch host {
 	case "bitbucket.org":
 		return buildBitbucketURL, nil
 	case "gitlab.com":
@@ -79,6 +82,5 @@ func getGitURLBuilder(baseURL url.URL) (buildURLFunc, error) {
 	case "github.com":
 		return buildGithubURL, nil
 	}
-	// TODO: Support Github Enterprise
 	return nil, errors.New("unknown git service")
 }


### PR DESCRIPTION
## What

Add the feature to read urltype, protocol from config

ex: 
```
$ git config gh-open.urltype github.com
$ git config gh-open.protocol http
```

## Why

To support to the repository that cannot be identified from the remote url

